### PR TITLE
Add attributed json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,18 @@ val libJsonParserChunky = project.in(file("json/parser-chunky"))
     libJsonParser
   )
 
+
+val libJsonAttributedModel = project.in(file("json/attributed/model"))
+  .settings(commonSettings)
+  .settings(
+    name := "json-attributed-model",
+    description :=
+      """Json object model with support for non-json model attributes.
+         | The attributes may define "auxilary" information like source location where element
+         | was defined.
+         |""".stripMargin
+  )
+
 val root = project.in(file("."))
   .settings(commonSettings)
   .settings(
@@ -69,4 +81,8 @@ val root = project.in(file("."))
     description :=
       """An (opinionated) set of small modular (faceted) libraries for the most common tasks"""
   )
-  .aggregate(libFun, libJsonClassic, libJsonParser, libJsonParserChunky)
+  .aggregate(
+    libFun,
+    libJsonClassic, libJsonParser, libJsonParserChunky,
+    libJsonAttributedModel
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,15 @@ val libJsonAttributedModel = project.in(file("json/attributed/model"))
          |""".stripMargin
   )
 
+val libJsonAttributedFactory = project.in(file("json/attributed/factory"))
+  .settings(commonSettings)
+  .settings(
+    name := "json-attributed-factory",
+    description := "Json model factories for use with the parsers provided by the platform."
+  )
+  .dependsOn(libJsonParser, libJsonAttributedModel)
+
+
 val root = project.in(file("."))
   .settings(commonSettings)
   .settings(
@@ -84,5 +93,5 @@ val root = project.in(file("."))
   .aggregate(
     libFun,
     libJsonClassic, libJsonParser, libJsonParserChunky,
-    libJsonAttributedModel
+    libJsonAttributedModel, libJsonAttributedFactory
   )

--- a/build.sbt
+++ b/build.sbt
@@ -78,9 +78,10 @@ val libJsonAttributedFactory = project.in(file("json/attributed/factory"))
   .settings(commonSettings)
   .settings(
     name := "json-attributed-factory",
-    description := "Json model factories for use with the parsers provided by the platform."
+    description := "Json model factories for use with the parsers provided by the platform.",
+    libraryDependencies += scalatest
   )
-  .dependsOn(libJsonParser, libJsonAttributedModel)
+  .dependsOn(libJsonParser, libJsonAttributedModel, libJsonParserChunky % "test")
 
 
 val root = project.in(file("."))

--- a/json/attributed/factory/src/Factory.scala
+++ b/json/attributed/factory/src/Factory.scala
@@ -1,0 +1,310 @@
+package io.github.maxkar
+package json.attr.factory
+
+import json.attr.Json
+import json.parser.factory.JsonFactory
+import json.parser.factory.TermFactory
+import json.parser.factory.StringFactory
+import json.parser.factory.NumberFactory
+import json.parser.factory.ArrayFactory
+import json.parser.factory.ObjectFactory
+
+import fun.Monad
+
+/**
+ * Json object/value factory compatible with the standard parser API.
+ * @tparam M calculation monad.
+ * @tparam L location representation in the source.
+ * @tparam A type of the json attributes.
+ * @param location location monad - a way to get current source location.
+ * @param locationToString tranformer from location to string (used in error messages).
+ * @param fail failure factor - encodes/transfers text message to failure execution.
+ * @param makeAttrs function to convert (start, end) location pair into attributes.
+ *   The function may choose what to encode (some scenarios may only need start location,
+ *   others may need both start and end locations). It may also encode additional information
+ *   like source file name.
+ */
+final class Factory[M[+_]: Monad, L, A](
+      location: M[L],
+      locationToString: L => String,
+      fail: String => M[Nothing],
+      makeAttrs: (L, L) => A)
+    extends JsonFactory[M, Json[A]]:
+
+
+  /**
+   * Implementation of term parser.
+   * @param fn function used to create value from attributes.
+   */
+  private final class TermFactoryImpl(fn: A => Json[A])
+      extends TermFactory[M, Json[A]]:
+    override type State = L
+
+    override def begin: M[State] = location
+    override def end(startLocation: State): M[Json[A]] =
+      for {
+        endLocation <- location
+      } yield
+        fn(makeAttrs(startLocation, endLocation))
+
+    override def badInput(startLocation: State, expectedTerm: String, offset: Int): M[Json[A]] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(startLocation)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Invalid/unexpected character of the ${expectedTerm} literal started at ${startStr}"
+        fail(msg)
+      }
+
+    override def unexpectedEnd(startLocation: State, expectedTerm: String, offset: Int): M[Json[A]] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(startLocation)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Unexpected end of file inside ${expectedTerm} literal started at ${startStr}"
+        fail(msg)
+      }
+  end TermFactoryImpl
+
+
+  /**
+   * Implementation of the string factory. There are slightly different contexts and usage so
+   * this parametrized class.
+   *
+   * @tparam T expected result type.
+   * @param convert function to make the expected type.
+   */
+  private final class StringFactoryImpl[T](convert: (String, L, L) => T) extends StringFactory[M, T]:
+    override type State = (L, StringBuilder)
+
+    override def begin: M[State] =
+      for loc <- location yield (loc, new StringBuilder())
+
+    override def update(state: State, input: CharSequence): (State, Boolean) = {
+      state._2.append(input)
+      (state, true)
+    }
+
+    override def update(state: State, input: Char): (State, Boolean) = {
+      state._2.append(input)
+      (state, true)
+    }
+
+    override def end(state: State): M[T] =
+      for {
+        endLocation <- location
+      } yield
+        convert(state._2.toString, state._1, endLocation)
+
+
+    override def badEscape(state: State): M[T] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Unexpected escaped character in string started at ${startStr}"
+        fail(msg)
+      }
+
+    override def badUnicodeEscape(state: State): M[T] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Unexpected unicode escape letter in string started at ${startStr}"
+        fail(msg)
+      }
+
+    override def badUnicodeEscape(state: State, c1: Char): M[T] =
+      badUnicodeEscape(state)
+
+    override def badUnicodeEscape(state: State, c1: Char, c2: Char): M[T] =
+      badUnicodeEscape(state)
+
+    override def badUnicodeEscape(state: State, c1: Char, c2: Char, c3: Char): M[T] =
+      badUnicodeEscape(state)
+
+    override def badCharacter(state: State): M[T] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Unexpected/illegal character in string started at ${startStr}"
+        fail(msg)
+      }
+
+    override def unterminatedString(state: State): M[T] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Unclosed string literal for string started at ${startStr}"
+        fail(msg)
+      }
+  end StringFactoryImpl
+
+
+  override val nullFactory: TermFactory[M, Json[A]] = new TermFactoryImpl(Json.Null.apply)
+  override val trueFactory: TermFactory[M, Json[A]] = new TermFactoryImpl(Json.True.apply)
+  override val falseFactory: TermFactory[M, Json[A]] = new TermFactoryImpl(Json.False.apply)
+
+
+  override val stringFactory = new StringFactoryImpl[Json[A]]((value, start, end) => Json.String(value, makeAttrs(start, end)))
+
+
+  override object numberFactory extends NumberFactory[M, Json[A]]:
+    override type State = (L, StringBuilder)
+
+    override def begin: M[State] =
+      for loc <- location yield (loc, new StringBuilder())
+
+    override def update(state: State, input: CharSequence): (State, Boolean) = {
+      state._2.append(input)
+      (state, true)
+    }
+
+    override def end(state: State): M[Json[A]] =
+      for {
+        endLocation <- location
+      } yield
+        Json.Number(state._2.toString, makeAttrs(state._1, endLocation))
+
+    override def missingIntDigits(state: State): M[Json[A]] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Missing integer part inside numeric literal started at ${startStr}"
+        fail(msg)
+      }
+
+    override def missingFractionalDigits(state: State): M[Json[A]] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Missing fractional digits inside numeric literal started at ${startStr}"
+        fail(msg)
+      }
+
+
+    override def missingExponentDigits(state: State): M[Json[A]] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Missing exponent digits inside numeric literal started at ${startStr}"
+        fail(msg)
+      }
+
+    override def digitsAfterLeadingZero(state: State): M[Json[A]] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Illegal digits after leading 0 in the numeric literal ${startStr}"
+        fail(msg)
+      }
+  end numberFactory
+
+
+  override object arrayFactory extends ArrayFactory[M, Json[A]]:
+    import scala.collection.mutable.ArrayBuffer
+
+    override type State = (L, ArrayBuffer[Json[A]])
+
+    override def begin: M[State] =
+      for loc <- location yield (loc, new ArrayBuffer[Json[A]]())
+
+    override def update(state: State, input: Json[A]): (State, Boolean) = {
+      state._2.append(input)
+      (state, true)
+    }
+
+    override def end(state: State): M[Json[A]] =
+      for {
+        endLocation <- location
+      } yield
+        Json.Array(state._2.toSeq, makeAttrs(state._1, endLocation))
+
+    override def badArrayContinuation(state: State): M[Json[A]] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Unexpected character inside array literal started at ${startStr}, comma or end of array is expected"
+        fail(msg)
+      }
+  end arrayFactory
+
+
+  override object objectFactory extends ObjectFactory[M, Json[A]]:
+    import scala.collection.mutable.HashMap
+
+    override type Key = (String, L, L)
+
+    /* State - initial location, current data, optional _duplicate_ key. */
+    override type State = (L, HashMap[String, (Key, Json[A])], Option[Key])
+
+
+    override val keyFactory: StringFactory[M, Key] =
+      new StringFactoryImpl[Key](
+        (value, start, end) => (value, start, end)
+      )
+
+    override def begin: M[State] =
+      for loc <- location yield (loc, new HashMap(), None)
+
+
+    override def update(state: State, key: Key, value: Json[A]): (State, Boolean) =
+      if state._2.contains(key._1)
+      then ((state._1, state._2, Some(key)), false)
+      else
+        state._2.put(key._1, (key, value))
+        (state, true)
+    end update
+
+
+    override def end(state: State): M[Json[A]] =
+      location.flatMap { endLocation =>
+        state._3 match
+          case Some((key, dupeStart, _)) =>
+            val startStr = locationToString(state._1)
+            val endStr = locationToString(dupeStart)
+            val prevOcc = locationToString(state._2(key)._1._2)
+            val msg = s"${endStr}: Duplicate key ${key} inside object started at ${startStr}, previous occurence at ${prevOcc}"
+            fail(msg)
+          case None =>
+            val objAttrs = makeAttrs(state._1, endLocation)
+            val elems = state._2.mapValues {
+              /* Unfortunately, only one level of untupling works automatically. */
+              case ((key, start, end), v) => Json.ObjectEntry(key, makeAttrs(start, end), v)
+            }
+            Monad.pure(Json.Object(elems.toMap, objAttrs))
+        end match
+      }
+
+    override def badKeyStart(state: State): M[Json[A]] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Unexpected character inside object literal started at ${startStr}, key expected"
+        fail(msg)
+      }
+
+
+    override def badObjectContinuation(state: State): M[Json[A]] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Unexpected character inside object literal started at ${startStr}, comma or end of object is expected"
+        fail(msg)
+      }
+
+
+    override def badKeyValueSeparator(state: State, key: Key): M[Json[A]] =
+      location.flatMap { endLocation =>
+        val startStr = locationToString(state._1)
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Unexpected character inside object literal started at ${startStr}, colon is expected"
+        fail(msg)
+      }
+  end objectFactory
+
+
+  override def badValue: M[Json[A]] =
+      location.flatMap { endLocation =>
+        val endStr = locationToString(endLocation)
+        val msg = s"${endStr}: Unexpected start of JSON value"
+        fail(msg)
+      }
+end Factory

--- a/json/attributed/factory/test/AttributeParsingTest.scala
+++ b/json/attributed/factory/test/AttributeParsingTest.scala
@@ -1,0 +1,135 @@
+package io.github.maxkar
+package json.attr.factory
+
+import json.attr.Json
+
+import json.parser.JsonParser
+
+import json.parser.chunky.Module
+import json.parser.chunky.SourceLocation
+
+
+/** Tests for attributed parsing that keeps location. */
+class AttributeParsingTest extends org.scalatest.funsuite.AnyFunSuite:
+  /** Parsing module & operations. */
+  private val module = Module[String](unexpectedEof = loc => s"${loc}: Unexpected EOF")
+  import module.given
+
+  /** Attributes of the resulting json. */
+  type Attrs = (SourceLocation, SourceLocation)
+
+
+  /** Factory of the json values. */
+  private val factory =
+    new Factory[module.Parser, SourceLocation, Attrs](
+      location = module.location,
+      locationToString = l => s"${l.line}:${l.column} (offset=${l.offset})",
+      fail = msg => module.abort(msg),
+      makeAttrs = (start, end) => (start, end)
+    )
+
+  /** Parser to use in tests. */
+  private val parser = new JsonParser(parserInput, factory)
+
+
+  test("Some basic literals work") {
+    assert(runParser("true") === Right(Json.True(lineAttr(0, 1, 1, 4))))
+    assert(runParser("false") === Right(Json.False(lineAttr(0, 1, 1, 5))))
+    assert(runParser("null") === Right(Json.Null(lineAttr(0, 1, 1, 4))))
+  }
+
+
+  test("Number parsing works") {
+    assert(runParser("1") === Right(Json.Number("1", lineAttr(0, 1, 1, 1))))
+    assert(runParser("1.25") === Right(Json.Number("1.25", lineAttr(0, 1, 1, 4))))
+    assert(runParser("1.25E+5") === Right(Json.Number("1.25E+5", lineAttr(0, 1, 1, 7))))
+  }
+
+
+  test("String parsing works") {
+    assert(runParser("\"a\"") === Right(Json.String("a", lineAttr(0, 1, 1, 3))))
+    assert(runParser("\"abc\"") === Right(Json.String("abc", lineAttr(0, 1, 1, 5))))
+    assert(runParser("\"a\\u0020c\"") === Right(Json.String("a c", lineAttr(0, 1, 1, 10))))
+  }
+
+
+  test("Array parsing works") {
+    assert(runParser("[]") === Right(Json.Array(Seq.empty, lineAttr(0, 1, 1, 2))))
+    assert(runParser("[true]") === Right(
+      Json.Array(
+        Seq(
+          Json.True(lineAttr(1, 1, 2, 4))
+        ),
+        lineAttr(0, 1, 1, 6))
+      )
+    )
+
+    assert(runParser("[true,\n false\n]") === Right(
+      Json.Array(
+        Seq(
+          Json.True(lineAttr(1, 1, 2, 4)),
+          Json.False(lineAttr(8, 2, 2, 5)),
+        ),
+        multilineAttr(0, 1, 1, 15, 3, 2))
+      )
+    )
+  }
+
+
+  test("Object parsing works") {
+    assert(runParser("{}") === Right(Json.Object(Map.empty, lineAttr(0, 1, 1, 2))))
+
+    val object1 = Json.Object(
+      Map(
+        "vl" -> Json.ObjectEntry("vl", lineAttr(1, 1, 2, 4), Json.True(lineAttr(7, 1, 8, 4)))
+      ),
+      lineAttr(0, 1, 1, 12)
+    )
+
+    val object2 = Json.Object(
+      Map(
+        "vl" -> Json.ObjectEntry("vl", lineAttr(4, 2, 3, 4), Json.True(lineAttr(10, 2, 9, 4))),
+        "vv" -> Json.ObjectEntry("vv", lineAttr(18, 3, 3, 4), Json.False(lineAttr(24, 3, 9, 5))),
+      ),
+      multilineAttr(0, 1, 1, 31, 4, 2)
+    )
+
+    assert(runParser("""{"vl": true}""") === Right(object1))
+    assert(runParser("{\n  \"vl\": true,\n  \"vv\": false\n}") === Right(object2))
+  }
+
+
+  /** Creates a "single-line" attribute. */
+  private def lineAttr(offset: Int, row: Int, column: Int, width: Int): Attrs =
+    val start = SourceLocation(offset, row, column)
+    val end = SourceLocation(offset + width, row, column + width)
+    (start, end)
+
+
+  /** Creates a multi-line attribute. */
+  private def multilineAttr(
+        startOffset: Int, startRow: Int, startCol: Int,
+        endOffset: Int, endRow: Int, endCol: Int): Attrs =
+    val start = SourceLocation(startOffset, startRow, startCol)
+    val end = SourceLocation(endOffset, endRow, endCol)
+    (start, end)
+
+
+  /** Runs the parser on the given input with with the given chunk size. */
+  private def runParser(input: String): Either[String, Json[Attrs]] =
+    val consumer = module.start(parser.parseValue)
+
+    var pos = 0
+    while pos < input.length do
+      val nextChunkSize = input.length - pos
+      val consumed = consumer.process(input.subSequence(pos, pos + nextChunkSize))
+      /* Consumer indicated that it does not want any more input. */
+      if consumed < nextChunkSize then
+        return consumer.end()
+
+      pos += consumed
+    end while
+
+    consumer.end()
+  end runParser
+end AttributeParsingTest

--- a/json/attributed/model/src/Json.scala
+++ b/json/attributed/model/src/Json.scala
@@ -1,0 +1,111 @@
+package io.github.maxkar
+package json.attr
+
+/**
+ * Single node in the JSON tree model.
+ * @tparam A type of the attributes that are applied to json.
+ */
+abstract sealed class Json[+A]:
+  /** Attributes of this JSON node. */
+  val attrs: A
+
+  /**
+   * Builds a new json by applying function to attributes of this json
+   * element and attributes of nested elemnts (if any). The calculation
+   * is eager.
+   * @param fn function to apply to json attributes.
+   */
+  def mapAttributes[R](fn: A => R): Json[R]
+end Json
+
+
+object Json:
+  /**
+   * Information about one entry in the json object. It captures information
+   * related to the object's key along with the value associated with the key.
+   *
+   * @param key key of the entry.
+   * @param keyAttrs attributes applicable to the entry's key.
+   * @param value value of the given entry.
+   */
+  case class ObjectEntry[+A](key: java.lang.String, keyAttrs: A, value: Json[A]):
+    /**
+     * Builds a new json entry by applying function to both key's and value's attributes.
+     * @param fn function to apply to json attributes.
+     */
+    def mapAttributes[R](fn: A => R): ObjectEntry[R] =
+      ObjectEntry(key, fn(keyAttrs), value.mapAttributes(fn))
+
+  end ObjectEntry
+
+
+  /** Representation of the json "null" literal. */
+  case class Null[+A](attrs: A) extends Json[A]:
+    override def mapAttributes[R](fn: A => R): Json[R] =
+      Null(fn(attrs))
+  end Null
+
+  /** Representation of the json "true" literal. */
+  case class True[+A](attrs: A) extends Json[A]:
+    override def mapAttributes[R](fn: A => R): Json[R] =
+      True(fn(attrs))
+  end True
+
+  /** Representation of the json "false" literal. */
+  case class False[+A](attrs: A) extends Json[A]:
+    override def mapAttributes[R](fn: A => R): Json[R] =
+      True(fn(attrs))
+  end False
+
+  /**
+   * JSON string literal.
+   * @param value value of the literal.
+   */
+  case class String[+A](value: java.lang.String, attrs: A) extends Json[A]:
+    override def mapAttributes[R](fn: A => R): Json[R] =
+      String(value, fn(attrs))
+  end String
+
+  /**
+   * String representation of the JSON numeric literal. The node contains
+   * "raw" (unparesd) value but ensures it is well-formed number according
+   * to the JSON.
+   * @param value raw (unparsed) value.
+   */
+  case class Number[+A](value: java.lang.String, attrs: A) extends Json[A]:
+    override def mapAttributes[R](fn: A => R): Json[R] =
+      String(value, fn(attrs))
+  end Number
+
+
+  /**
+   * Json array.
+   * @param elements elemenst of the JSON array.
+   * @param attrs attributes applicable to this array.
+   */
+  case class Array[+A](elements: Seq[Json[A]], attrs: A) extends Json[A]:
+    /** Retrieves nth element of the array. */
+    def apply(index: Int): Json[A] = elements(index)
+
+    override def mapAttributes[R](fn: A => R): Json[R] =
+      Array(elements.map(_.mapAttributes(fn)), fn(attrs))
+  end Array
+
+
+  /**
+   * Json object.
+   * @param elements entries of the object (object keys must match map entry keys).
+   * @param attrs attributes of this json value (complete object).
+   */
+  case class Object[+A](elements: Map[java.lang.String, ObjectEntry[A]], attrs: A) extends Json[A]:
+    /** Retrieves value associated with the given key. */
+    def apply(key: java.lang.String): Json[A] = elements(key).value
+
+    /** Retrieves optional value associated with the key. */
+    def get(key: java.lang.String): Option[Json[A]] = elements.get(key).map(_.value)
+
+    override def mapAttributes[R](fn: A => R): Json[R] =
+      Object(elements.view.mapValues(_.mapAttributes(fn)).toMap, fn(attrs))
+  end Object
+
+end Json


### PR DESCRIPTION
Add JSON "DOM" model that may contain additional attributes like source location of the attribute. It may be used to generate more human-friendly messages when some data does not match expected format. For example, the application may point to the specific location in the source file where value has incorrect (unexpected) type.