### PR TITLE
Add construction/update syntax for simple JSON

### DIFF
--- a/json/simple/src/defaultConversions.scala
+++ b/json/simple/src/defaultConversions.scala
@@ -17,6 +17,13 @@ given jsonToBoolean: Function[Json, Either[String, Boolean]] with
 end jsonToBoolean
 
 
+/** Conversion from boolean to json. */
+given booleanToJson: Conversion[Boolean, Json] with
+  override def apply(x: Boolean): Json =
+    if x then Json.True else Json.False
+end booleanToJson
+
+
 /**
  * Conversion from JSON to string value.
  */
@@ -28,6 +35,12 @@ given jsonToString: Function[Json, Either[String, String]] with
     end match
   end apply
 end jsonToString
+
+
+/** Conversion from string to json. */
+given stringToJson: Conversion[String, Json] with
+  override def apply(x: String): Json = Json.String(x)
+end stringToJson
 
 
 /**
@@ -48,6 +61,11 @@ given jsonToInt: Function[Json, Either[String, Int]] with
   end apply
 end jsonToInt
 
+/** Converts int to json. */
+given intToJson: Conversion[Int, Json] with
+  override def apply(x: Int): Json = Json.Number(x.toString())
+end intToJson
+
 
 /**
  * Conversion from JSON to long value.
@@ -66,6 +84,11 @@ given jsonToLong: Function[Json, Either[String, Long]] with
     end match
   end apply
 end jsonToLong
+
+/** Converts long to json. */
+given longToJson: Conversion[Long, Json] with
+  override def apply(x: Long): Json = Json.Number(x.toString())
+end longToJson
 
 
 /**
@@ -86,6 +109,10 @@ given jsonToFloat: Function[Json, Either[String, Float]] with
   end apply
 end jsonToFloat
 
+/** Converts float to json. */
+given floatToJson: Conversion[Float, Json] with
+  override def apply(x: Float): Json = Json.Number(x.toString())
+end floatToJson
 
 /**
  * Conversion from JSON to double value.
@@ -105,9 +132,14 @@ given jsonToDouble: Function[Json, Either[String, Double]] with
   end apply
 end jsonToDouble
 
+/** Converts double to json. */
+given doubleToJson: Conversion[Double, Json] with
+  override def apply(x: Double): Json = Json.Number(x.toString())
+end doubleToJson
+
 
 /**
- * Conversion from JSON to BigDecimal.
+ * Conversion from JSON to BigInt.
  */
 given jsonToBigInt: Function[Json, Either[String, BigInt]] with
   override def apply(v: Json): Either[String, BigInt] =
@@ -124,6 +156,10 @@ given jsonToBigInt: Function[Json, Either[String, BigInt]] with
   end apply
 end jsonToBigInt
 
+/** Converts BigInt to json. */
+given bigIntToJson: Conversion[BigInt, Json] with
+  override def apply(x: BigInt): Json = Json.Number(x.toString())
+end bigIntToJson
 
 /**
  * Conversion from JSON to BigDecimal.
@@ -143,6 +179,10 @@ given jsonToBigDecimal: Function[Json, Either[String, BigDecimal]] with
   end apply
 end jsonToBigDecimal
 
+/** Converts BigDecimal to json. */
+given bigDecimalToJson: Conversion[BigDecimal, Json] with
+  override def apply(x: BigDecimal): Json = Json.Number(x.toString())
+end bigDecimalToJson
 
 /**
  * Noop conversion. Could be used to derive JSON value or optional JSON value

--- a/json/simple/test/ConstructorSyntaxTest.scala
+++ b/json/simple/test/ConstructorSyntaxTest.scala
@@ -1,0 +1,144 @@
+package io.github.maxkar
+package json.simple
+
+import defaultConversions.given
+
+import scala.language.implicitConversions
+
+/**
+ * Tests for simple json construction syntax.
+ */
+final class ConstructorSyntaxTest extends org.scalatest.funsuite.AnyFunSuite:
+
+  test("Smoke construction test") {
+    check(Json.True, true)
+    check(Json.False, false)
+    check(Json.String("Hello, Scala!"), "Hello, Scala!")
+    check(Json.Number("123"), 123)
+    check(Json.Number("123"), 123L)
+    check(Json.Number("123.5"), 123.5f)
+    check(Json.Number("123.5"), 123.5)
+    check(Json.Number("213"), BigInt("213"))
+    check(Json.Number("213.25"), BigDecimal("213.25"))
+  }
+
+
+  test("Array construction and manipulation syntax") {
+    check(Json.Array(Seq(Json.True, Json.False)), Json.array(true, false))
+    check(Json.Array(Seq(Json.True)), Json.array(true, Json.Empty))
+    check(Json.Array(Seq(Json.False)), Json.array(Json.Empty, false))
+
+    val baseSeq = Seq(Json.Number("42"))
+    val base = Json.array(42)
+
+    check(Json.Array(baseSeq), base)
+    check(Json.Array(baseSeq ++ baseSeq), base.update(42))
+    check(Json.Array(baseSeq :+ Json.Number("44")), base.update(Json.Empty, 44))
+
+    val deepArray =
+      Json.Array(Seq(
+        Json.Array(Seq(
+          Json.True, Json.False
+        ))
+      ))
+
+    check(deepArray, Seq(Seq(true, false)))
+
+    check(deepArray, Seq(Seq(Some(true), Some(false), None)))
+    check(deepArray, Seq(Seq(Some(true), None, Some(false), None)))
+    check(deepArray, Seq(Some(Seq(Some(true), None, Some(false), None)), None))
+  }
+
+
+  test("Object construction and manipulation syntax") {
+    check(
+      Json.Object(Map("a" -> Json.True, "b" -> Json.False)),
+      Json.make("a" -> true, "b" -> false)
+    )
+
+    check(
+      Json.Object(Map("a" -> Json.True, "b" -> Json.String("false"))),
+      Json.make("a" -> true, "b" -> "false")
+    )
+
+    check(
+      Json.Object(Map("a" -> Json.True, "b" -> Json.String("false"))),
+      Json.make("a" -> true, "b" -> "false", "c" -> (None: Option[String]))
+    )
+
+    val baseMap = Map("a" -> Json.True, "b" -> Json.Number("42"))
+    val base = Json.make("a" -> true, "b" -> 42)
+
+    check(Json.Object(baseMap), base)
+
+    check(Json.Object(baseMap + ("c" -> Json.False)), base.update("c" -> false))
+    check(Json.Object(baseMap + ("c" -> Json.False)), base.update("c" -> Some(false)))
+    check(Json.Object(baseMap + ("c" -> Json.False)), base.update("c" -> Some(false)))
+    check(Json.Object(baseMap), base.update("c" -> (None: Option[Boolean])))
+    check(Json.Object(baseMap - "a"), base.update("a" -> Json.Remove))
+    check(Json.Object(baseMap - "a" + ("c" -> Json.True)), base.update("a" -> Json.Remove, "c" -> true))
+
+    val deepObject =
+      Json.Object(Map(
+        "a" -> Json.Object(Map(
+          "b" -> Json.True,
+          "c" -> Json.False,
+        )),
+        "d" -> Json.Object(Map(
+          "e" -> Json.False
+        ))
+      ))
+
+    check(
+      deepObject,
+      Map(
+        "a" -> Map("b" -> true, "c" -> false),
+        "d" -> Map("e" -> false)
+      )
+    )
+
+    check(
+      deepObject,
+      Map(
+        "a" -> Map("b" -> Some(true), "c" -> Some(false)),
+        "d" -> Map("e" -> Some(false), "f" -> None)
+      )
+    )
+  }
+
+
+  test("Combining optionals, map and array conversions in one place works") {
+    val x: Seq[Option[Map[String, Option[Boolean]]]] =
+      Seq(
+        Some(Map(
+          "a" -> Some(true),
+          "b" -> None,
+          "c" -> Some(false)
+        )),
+        None,
+        None,
+        Some(Map(
+          "e" -> None,
+          "f" -> Some(true)
+        ))
+      )
+
+    val expected =
+      Json.Array(Seq(
+        Json.Object(Map(
+          "a" -> Json.True,
+          "c" -> Json.False,
+        )),
+        Json.Object(Map(
+          "f" -> Json.True
+        )),
+      ))
+
+    check(expected, x)
+  }
+
+
+  /** Checks that x and y match. Most useful for implicit value conversion tests. */
+  private def check(x: Json, y: Json): Unit =
+    assert(x === y)
+end ConstructorSyntaxTest

--- a/json/simple/test/ConversionAndSyntaxTest.scala
+++ b/json/simple/test/ConversionAndSyntaxTest.scala
@@ -26,7 +26,7 @@ final class ConversionAndSyntaxTest extends org.scalatest.funsuite.AnyFunSuite:
         "b" -> Json.Number("23")
       ))
 
-    val q = Query(model)
+    val q = Query(model: Json)
     assert(q.b.as[Int] === 23)
     assert(q.a.as[Boolean] === true)
     assert(q.c.as[Option[String]] === None)
@@ -38,7 +38,7 @@ final class ConversionAndSyntaxTest extends org.scalatest.funsuite.AnyFunSuite:
 
   test("Array derivations work") {
     val model1 = Json.Array(Seq(Json.True, Json.True, Json.False))
-    val q1 = Query(model1)
+    val q1 = Query(model1: Json)
 
     assert(q1.as[Seq[Boolean]] === Seq(true, true, false))
 
@@ -48,7 +48,7 @@ final class ConversionAndSyntaxTest extends org.scalatest.funsuite.AnyFunSuite:
         Json.Array(Seq.empty),
         Json.Array(Seq(Json.Number("44.5"), Json.Number("22.5")))
       ))
-    val q2 = Query(model2)
+    val q2 = Query(model2: Json)
     val expected2 =
       Seq(
         Seq(BigDecimal("22")),
@@ -63,7 +63,7 @@ final class ConversionAndSyntaxTest extends org.scalatest.funsuite.AnyFunSuite:
     val model1 = Json.Object(Map(
       "a" -> Json.True, "b" -> Json.True, "c" -> Json.False
     ))
-    val q1 = Query(model1)
+    val q1 = Query(model1: Json)
 
     assert(q1.as[Map[String, Boolean]] === Map("a" -> true, "b" -> true, "c" -> false))
 
@@ -73,7 +73,7 @@ final class ConversionAndSyntaxTest extends org.scalatest.funsuite.AnyFunSuite:
         "b" -> Json.Object(Map.empty),
         "c" -> Json.Object(Map("ff" -> Json.Number("44.5"), "tt" -> Json.Number("22.5")))
       ))
-    val q2 = Query(model2)
+    val q2 = Query(model2: Json)
     val expected2 =
       Map(
         "a" -> Map("tt" -> BigDecimal("22")),

--- a/json/simple/test/MonadicConversionTest.scala
+++ b/json/simple/test/MonadicConversionTest.scala
@@ -147,10 +147,10 @@ final class MonadicConversionTest extends org.scalatest.funsuite.AnyFunSuite:
 
     val expectedDto = Right(Dto(45, "Hello, Monad", false, Inner(Seq(1, 2, 3))))
 
-    val maybeDto1 = parseDto(Query(stupid)("map", 0))
+    val maybeDto1 = parseDto(Query(stupid: Json)("map", 0))
     assert(maybeDto1 === expectedDto)
 
-    val maybeDto2 = parseDto(Query(stupid) / "map" / 0)
+    val maybeDto2 = parseDto(Query(stupid: Json) / "map" / 0)
     assert(maybeDto2 === expectedDto)
 
 
@@ -161,7 +161,7 @@ final class MonadicConversionTest extends org.scalatest.funsuite.AnyFunSuite:
         ))
       ))
 
-    val maybeDto3 = parseDto(Query(lessStupid).data(0))
+    val maybeDto3 = parseDto(Query(lessStupid: Json).data(0))
     assert(maybeDto3 === expectedDto)
   }
 


### PR DESCRIPTION
The simple JSON is aimed as a good-enough replacement for the classic JSON (it uses better IO apis and integrates with JSON Query that is able to provide better error messages). So it needs a "simple construction" API for creating new values. The change provides those construction options.

The change also provides a new "remove values" syntax for objects that looks like
```
val x: Json.Object = ???
x.update(
  "a" -> Json.Remove
)
```
(the code above will remove value associated with the "a" key).

The change breaks old Query code due to typing change (Json is no longer enum to support different method sets on Objects, Arrays and simple values). The query integration is defined on Json values only and thus more specific elements now need a (upward) cast. It may be possible to avoid this by adding more generic parameters to the query-related conversions, but it would complicate code (and troubleshooting) without adding much value. Queries are expected to work with values that come from external sources. Such values will have "dynamic" nature and the base type of Json so queries will match naturally. More specific types (like Arrays and Objects) are generated by "construction" API and is unlikely to require parsing (the necessary data may be passed between methods without putting it into JSON).