### PR TITLE
Replace unicode arrows with ASCII Art

### DIFF
--- a/fun/src/typeclass/Applicative.scala
+++ b/fun/src/typeclass/Applicative.scala
@@ -16,7 +16,7 @@ trait Applicative[M[_]] extends Functor[M]:
 
 
   extension [S, R](fn: M[S => R])
-    inline infix def ≻(v: M[S]): M[R] =
+    inline infix def |>(v: M[S]): M[R] =
       Applicative.this.aapply(v, fn)
 
 end Applicative

--- a/fun/src/typeclass/Functor.scala
+++ b/fun/src/typeclass/Functor.scala
@@ -10,12 +10,12 @@ trait Functor[M[_]]:
     inline def map[R](fn: S => R): M[R] =
       Functor.this.fmap(x, fn)
 
-    inline infix def ≺[R](fn: S => R): M[R]  =
+    inline infix def <|[R](fn: S => R): M[R]  =
       Functor.this.fmap(x, fn)
 
 
   extension [S, R](fn: S => R)
-    inline infix def ≻≻ (v: M[S]): M[R] =
+    inline infix def ||> (v: M[S]): M[R] =
       Functor.this.fmap(v, fn)
 
 end Functor

--- a/fun/src/typeclass/Monad.scala
+++ b/fun/src/typeclass/Monad.scala
@@ -29,18 +29,18 @@ trait Monad[M[_]] extends Applicative[M]:
         (vv: S) => if fn(vv) then vv else throw new Exception("No match in monad for comprehension")
       )
 
-    inline infix def ≼[R](fn: S => M[R]) =
+    inline infix def <|||[R](fn: S => M[R]) =
       Monad.this.bind(v, fn)
 
 
 
   extension [S, R](fn: S => M[R])
-    inline infix def ≽(v: M[S]): M[R] =
+    inline infix def |||>(v: M[S]): M[R] =
       Monad.this.bind(v, fn)
 
 
   extension [S, R](fn: M[S => M[R]])
-    inline infix def ≽(v: M[S]): M[R] =
+    inline infix def |||>(v: M[S]): M[R] =
       Monad.this.flatten(Monad.this.aapply(v, fn))
 end Monad
 

--- a/fun/test/typeclass/SyntaxTest.scala
+++ b/fun/test/typeclass/SyntaxTest.scala
@@ -38,7 +38,7 @@ final class SyntaxTest extends org.scalatest.funsuite.AnyFunSuite:
     def calc[M[_]: Monad](x: Int)(y: Int): M[Int] =
       Monad.pure(x + y)
 
-    assert((calc ≻≻ a ≽ b) === Some(7))
+    assert((calc ||> a |||> b) === Some(7))
   }
 
 

--- a/json/attributed/test/MonadicConversionTest.scala
+++ b/json/attributed/test/MonadicConversionTest.scala
@@ -63,15 +63,15 @@ final class MonadicConversionTest extends org.scalatest.funsuite.AnyFunSuite:
 
   /** Parse inner object in a cool way. */
   def parseInner(q: Query[Json[Attrs]]): Md[Inner] =
-    Inner.apply ≻≻ q
+    Inner.apply ||> q
 
 
   /** Parse outer dto in a cool way. */
   def parseDto(q: Query[Json[Attrs]]): Md[Dto] =
-    Dto.apply.curried ≻≻
-      q.x ≻
-      q.y ≻
-      q.z ≻
+    Dto.apply.curried ||>
+      q.x |>
+      q.y |>
+      q.z |>
       parseInner(q.inner)
 
 

--- a/json/simple/test/MonadicConversionTest.scala
+++ b/json/simple/test/MonadicConversionTest.scala
@@ -83,15 +83,15 @@ final class MonadicConversionTest extends org.scalatest.funsuite.AnyFunSuite:
 
   /** Parse inner object in a cool way. */
   def parseInner(q: Query[Json]): Md[Inner] =
-    Inner.apply ≻≻ q
+    Inner.apply ||> q
 
 
   /** Parse outer dto in a cool way. */
   def parseDto(q: Query[Json]): Md[Dto] =
-    Dto.apply.curried ≻≻
-      q.x ≻
-      q.y ≻
-      q.z ≻
+    Dto.apply.curried ||>
+      q.x |>
+      q.y |>
+      q.z |>
       parseInner(q.inner)
 
 


### PR DESCRIPTION
Replace unicode arrows (used for functor/applicative/monad pipes) with ASCII pipes |>, ||>, |||>. These are easy to input on all terminals and do not require special input support (iabbr is not supported by VIM vscode extension). The pipes still looks nice when fonts with ligatures (like Fira Code) is used. The same pipe still look OK in non-ligature non-unicode fonts.