### PR TITLE
Simple db worker

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,25 @@ val libSqlCore = project.in(file("sql/core"))
       """.stripMargin,
       libraryDependencies ++= Seq(scalatest, hsqldb)
   )
-  .dependsOn(libFun)
+
+
+val libSqlDatabaseStatic = project.in(file("sql/database/static"))
+  .settings(commonSettings)
+  .settings(
+    name := "sql-database-static",
+    description :=
+      """
+        |A fixed-size implementation of the Database access typeclass. This is an
+        | "inversion" of the regular pool pattern - resources are not provided from
+        | the pool but instead the tasks are provided to the database access.
+        |
+        | The implementation provided by this module maintains a fixed-size number
+        | of database connections (and corresponding I/O threads) that may handle the
+        | query tasks.
+      """.stripMargin,
+      libraryDependencies ++= Seq(scalatest, hsqldb)
+  )
+  .dependsOn(libSqlCore)
 
 
 val httpHeaders = project.in(file("http/headers"))
@@ -243,7 +261,7 @@ val root = project.in(file("."))
     libJsonSimple, libJsonAttributed,
     sampleJsonStreamingFormatter,
 
-    libSqlCore,
+    libSqlCore, libSqlDatabaseStatic,
 
     httpHeaders, httpServerApi, httpServerToolkit,
     httpServerJettyGateway, httpServerJettyQoS,

--- a/sql/database/static/src/Configuration.scala
+++ b/sql/database/static/src/Configuration.scala
@@ -41,10 +41,15 @@ object Configuration:
    * @param queryTimeoutMs timeout to use on the validation query.
    * @param validateOnIdleMsTimeout timeout to use for validating an "idle"
    *   connection. Set to 0 or negative value to avoid validation.
+   * @param validateUrl if the URL (connection) should be validated on the service
+   *   start-up (not inside the worker). The service won't start if the `validateUrl`
+   *   is set and connection could not be established. Otherwise the service will
+   *   start but connections would be unavailable for tasks.
    */
   case class Validation(
       validationTimeoutMs: Int = 5000,
       validateOnIdleMsTimeout: Int = 30000,
+      validateUrl: Boolean = true,
   )
 
 

--- a/sql/database/static/src/Configuration.scala
+++ b/sql/database/static/src/Configuration.scala
@@ -1,0 +1,75 @@
+package io.github.maxkar
+package sql.database.static
+
+import java.util.concurrent.ThreadFactory
+
+/**
+ * Configuration of the database access - ways to access the database and how/when
+ * to check the connection.
+ *
+ * @param connection connection configuration - what is the database address.
+ * @param poolSize number of connections to have and maintain.
+ * @param threadFactory factory to use for database access threads. Uses a thread
+ *   factory that creates daemon threads by default.
+ * @param backoffFactory factory for creating back-off strategies for individual
+ *   threads and connections.
+ * @param validation connection validation configuration.
+ */
+case class Configuration(
+      connection: Configuration.Connection,
+      poolSize: Int = 1,
+      threadFactory: ThreadFactory = Configuration.defaultThreadFactory,
+      backoffFactory: backoff.BackoffFactory = Configuration.defaultBackoffFactory,
+      validation: Configuration.Validation = Configuration.defaultValidation,
+    )
+
+
+object Configuration:
+  /** How to connect to the database. */
+  enum Connection:
+    /** Simple URL but no login/password. */
+    case NoCredentials(url: String)
+    /** Login and password are available for connection. */
+    case LoginPassword(url: String, login: String, password: String)
+    /** Property-based configuration. */
+    case PropertyBased(url: String, properties: java.util.Properties)
+  end Connection
+
+
+  /**
+   * Connection validation options.
+   * @param queryTimeoutMs timeout to use on the validation query.
+   * @param validateOnIdleMsTimeout timeout to use for validating an "idle"
+   *   connection. Set to 0 or negative value to avoid validation.
+   */
+  case class Validation(
+      validationTimeoutMs: Int = 5000,
+      validateOnIdleMsTimeout: Int = 30000,
+  )
+
+
+  /** Default connection validation parameters. */
+  val defaultValidation: Validation = Validation()
+
+
+  /** Default thread factory implementation. */
+  private lazy val defaultThreadFactory: ThreadFactory =
+    new ThreadFactory {
+      /** Counter of the threads. */
+      private val threadCounter = new java.util.concurrent.atomic.AtomicInteger()
+
+      override def newThread(x: Runnable): Thread =
+        val res = new Thread(x)
+        res.setDaemon(true)
+        res.setName(s"Database access thread ${threadCounter.incrementAndGet()}")
+        res
+      end newThread
+    }
+
+
+  /** Default backoff factory. */
+  private lazy val defaultBackoffFactory: backoff.BackoffFactory =
+    backoff.Strategies.randomizedDoubleExponent(25, 60_000)
+
+
+end Configuration

--- a/sql/database/static/src/FifoTaskProvider.scala
+++ b/sql/database/static/src/FifoTaskProvider.scala
@@ -1,0 +1,48 @@
+package io.github.maxkar
+package sql.database.static
+
+import sql.connection.AutocommitConnection
+
+import scala.collection.mutable.Queue
+
+/**
+ * First-in/first-out implementation of the task provider.
+ * @tparam T type of the task managed by the queue.
+ */
+final class FifoTaskProvider extends TaskProvider:
+  /** Synchronization primitive. */
+  private val lock = new Object()
+
+  /** Indicates if we should shutdown. */
+  private var stopped = false
+
+  /** Queue of tasks to execute. */
+  private val queue = new Queue[AutocommitConnection => Unit]()
+
+
+  /** Submits a task for execution. */
+  def submit(task: AutocommitConnection => Unit): Unit =
+    lock synchronized {
+      if (stopped) then
+        return
+      queue.append(task)
+      lock.notify()
+    }
+
+
+  override def getNextTask(timeoutMs: Int): AutocommitConnection => Unit =
+    lock synchronized {
+      while !stopped && queue.isEmpty do
+        lock.wait()
+      return if stopped then null else queue.dequeue()
+    }
+
+
+  override def shutdown(): Unit =
+    lock synchronized {
+      if stopped then
+        return
+      stopped = true
+      lock.notifyAll()
+    }
+end FifoTaskProvider

--- a/sql/database/static/src/Sensor.scala
+++ b/sql/database/static/src/Sensor.scala
@@ -1,0 +1,62 @@
+package io.github.maxkar
+package sql.database.static
+
+
+/**
+ * Sensor for various database events. May be called from multiple threads.
+ */
+trait Sensor:
+  /** Invoked when a new connection is about to be created. */
+  def createConnectionStarted(): Unit
+
+  /** Invoked after a new DB connection was created successfully. */
+  def createConnectionSuccessful(): Unit
+
+  /** Invoked when a new connection could not be created due to an exception. */
+  def createConnectionFailed(t: Throwable): Unit
+
+
+  /** Invoked before a task starts. */
+  def taskStarted(): Unit
+
+  /** Invoked when task is executed successfully. */
+  def taskSuccess(): Unit
+
+  /** Invoked when task fails. */
+  def taskFailed(exn: Throwable): Unit
+
+
+  /** Invoked before validation starts. */
+  def validationStarted(): Unit
+
+  /** Invoked when validation completes. */
+  def validationComplete(isValid: Boolean): Unit
+
+  /** Invoked when validation fails due to an exception. */
+  def validationFailed(e: Throwable): Unit
+
+
+  /** Invoked when a general (mysterious) exception occurs. */
+  def generalError(e: Throwable): Unit
+end Sensor
+
+
+object Sensor:
+  /** No-operation sensor. */
+  val noop: Sensor =
+    new Sensor {
+      override def createConnectionStarted(): Unit = ()
+      override def createConnectionSuccessful(): Unit = ()
+      override def createConnectionFailed(t: Throwable): Unit = ()
+
+      override def taskStarted(): Unit = ()
+      override def taskSuccess(): Unit = ()
+      override def taskFailed(exn: Throwable): Unit = ()
+
+      override def validationStarted(): Unit = ()
+      override def validationComplete(isValid: Boolean): Unit = ()
+      override def validationFailed(e: Throwable): Unit = ()
+
+      override def generalError(e: Throwable): Unit = ()
+    }
+end Sensor

--- a/sql/database/static/src/Service.scala
+++ b/sql/database/static/src/Service.scala
@@ -62,6 +62,11 @@ object Service:
         tasks: TaskProvider,
         sensor: Sensor,
       ): Service =
+
+    /* Validate the URL by opening and then closing the connection. */
+    if configuration.validation.validateUrl then
+      Worker.openConnection(configuration.connection).close()
+
     val alive = new AtomicBoolean(true)
 
     val threads =

--- a/sql/database/static/src/Service.scala
+++ b/sql/database/static/src/Service.scala
@@ -1,0 +1,86 @@
+package io.github.maxkar
+package sql.database.static
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+
+/**
+ * Database management service. Provides management facilities for the database access service.
+ *
+ * @param isAlive global "is thread alive" flag.
+ * @param threads worker threads and their backoff instances.
+ * @param tasks task provider.
+ */
+final class Service private(
+      isAlive: AtomicBoolean,
+      threads: Seq[(Thread, backoff.Backoff)],
+      tasks: TaskProvider
+    ):
+
+  /**
+   * Requests that all processing is stopped but does not await until
+   * threads are terminated.
+   */
+  def requestShutdown(): Unit =
+    isAlive.set(false)
+    tasks.shutdown()
+    threads.foreach { t => t._2.shutdown() }
+  end requestShutdown
+
+
+  /**
+   * Awaits until all the processing is terminated (i.e. until all
+   * active requests complete).
+   */
+  def awaitShutdown(): Unit =
+    if isAlive.get() then
+      throw new IllegalStateException("Could not await shutdown as it was not requested")
+    threads.foreach(_._1.join())
+  end awaitShutdown
+
+
+  /**
+   * Requests processing termination and awaits until all the active operations
+   * are complete.
+   */
+  def shutdown(): Unit =
+    requestShutdown()
+    awaitShutdown()
+  end shutdown
+end Service
+
+
+object Service:
+  /**
+   * Creates and starts a new database access service.
+   * @param configuration database access configuration.
+   * @param tasks task provider that provides things to execute on the connection.
+   * @param sensor sensor for the events arising in this service.
+   */
+  def apply(
+        configuration: Configuration,
+        tasks: TaskProvider,
+        sensor: Sensor,
+      ): Service =
+    val alive = new AtomicBoolean(true)
+
+    val threads =
+      Seq.fill(configuration.poolSize) {
+        val backoff = configuration.backoffFactory.newBackoff()
+        val worker = new Worker(
+          connection = configuration.connection,
+          backoffStrategy = backoff,
+          validation = configuration.validation,
+          taskProvider = tasks,
+          sensor = sensor,
+          alive = alive
+        )
+
+        val thread = configuration.threadFactory.newThread(worker)
+        thread.start()
+        (thread, backoff)
+      }
+
+    new Service(alive, threads, tasks)
+  end apply
+end Service

--- a/sql/database/static/src/TaskProvider.scala
+++ b/sql/database/static/src/TaskProvider.scala
@@ -1,0 +1,27 @@
+package io.github.maxkar
+package sql.database.static
+
+import sql.connection.AutocommitConnection
+
+/**
+ * A provider of tasks that would be executed on the connection pool.
+ */
+trait TaskProvider:
+  /**
+   * Gets a next task to execute on the connection (if any). This method
+   * may be called from multiple threads simultaneously.
+   *
+   * @param timeoutMs maximal timeout to wait for a task.
+   * @return a next task to execute. Returns `null` if the timeout has
+   *   passed and no tasks are available. Also returns `null` if
+   *   `shutdown` was called.
+   */
+  def getNextTask(timeoutMs: Int): AutocommitConnection => Unit
+
+
+  /**
+   * Indicates that this specific task provider should no longer return any
+   * instances and is safe to terminate.
+   */
+  def shutdown(): Unit
+end TaskProvider

--- a/sql/database/static/src/Worker.scala
+++ b/sql/database/static/src/Worker.scala
@@ -1,0 +1,148 @@
+package io.github.maxkar
+package sql.database.static
+
+import java.sql.Driver
+import java.sql.DriverManager
+import java.sql.{Connection => JdbcConnection}
+
+import sql.connection.AutocommitConnection
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+
+/**
+ * A database worker (worker thread).
+ *
+ * @param connection connection options.
+ * @param backoffStrategy back-off strategy instance for use on connection attempts.
+ * @param validation connection validation configuration.
+ * @param taskProvider provider of the tasks to execute on the worker.
+ * @param sensor sensor for various events that happen during connection lifecycle.
+ * @param alive indicates that we are "alive" - should try and work. If set to false,
+ *   the worker have to terminate.
+ */
+private final class Worker(
+      connection: Configuration.Connection,
+      backoffStrategy: backoff.Backoff,
+      validation: Configuration.Validation,
+      taskProvider: TaskProvider,
+      sensor: Sensor,
+      alive: AtomicBoolean,
+    ) extends Runnable:
+
+
+  override def run(): Unit =
+    var conn = connect()
+
+    while conn != null && alive.get() do
+      try
+        serveUsing(conn)
+      catch
+        case e: Throwable => sensor.generalError(e)
+      finally
+        try
+          conn.close()
+        catch
+          case e: Throwable => sensor.generalError(e)
+        end try
+      end try
+
+      conn = connect()
+    end while
+  end run
+
+
+  /**
+   * Attempts to get a connection using connection properties and back-off strategy.
+   * Returns a connection or `null` if termination condition was reached.
+   */
+  private def connect(): JdbcConnection =
+    while alive.get() do
+      sensor.createConnectionStarted()
+      try
+        val res =
+          connection match
+            case Configuration.Connection.NoCredentials(url) =>
+              DriverManager.getConnection(url)
+            case Configuration.Connection.LoginPassword(url, login, password) =>
+              DriverManager.getConnection(url, login, password)
+            case Configuration.Connection.PropertyBased(url, properties) =>
+              DriverManager.getConnection(url, properties)
+          end match
+        sensor.createConnectionSuccessful()
+        backoffStrategy.reset()
+        return res
+      catch
+        case e: Throwable =>
+          sensor.createConnectionFailed(e)
+          backoffStrategy.handleFailure()
+      end try
+    end while
+
+    return null
+  end connect
+
+
+  /**
+   * Runs the process using the active connection. Returns at the moment
+   * connection is indicated to be invalid.
+   */
+  private def serveUsing(conn: JdbcConnection): Unit =
+    while alive.get() do
+      val task = taskProvider.getNextTask(validation.validateOnIdleMsTimeout)
+      /* If the task is not null, then there is no timeout and we should execute
+       * the task. Otherwise it was either shutdown or timeout before validation,
+       * in both these cases it is safe to call validate to handle both cases.
+       *
+       * In both cases if validation fails then return from this method as connection
+       * should be re-established.
+       */
+      if task != null then
+        /*
+         * Only run validation if task failed. Otherwise assume that task used the connection
+         * successfully and it is valid.
+         */
+        if !runTask(conn, task) && !validate(conn) then
+          return
+      else
+        if !validate(conn) then
+          return
+      end if
+    end while
+  end serveUsing
+
+
+  /**
+   * Runs one task on the connection.
+   * @return `true` if task completed successfully and `false` otherwise.
+   */
+  private def runTask(conn: JdbcConnection, task: AutocommitConnection => Unit): Boolean =
+    sensor.taskStarted()
+    try
+      task(new AutocommitConnection(conn))
+      sensor.taskSuccess()
+      true
+    catch
+      case e: Throwable =>
+        sensor.taskFailed(e)
+        false
+    end try
+  end runTask
+
+
+  /** Checks if the existing connection is valid and could be used. */
+  private def validate(conn: JdbcConnection): Boolean =
+    if !alive.get() then
+      return false
+    sensor.validationStarted()
+    try
+      val res = conn.isValid(validation.validationTimeoutMs)
+      sensor.validationComplete(res)
+      res
+    catch
+      case e: Throwable =>
+        sensor.validationFailed(e)
+        false
+    end try
+  end validate
+end Worker

--- a/sql/database/static/src/Worker.scala
+++ b/sql/database/static/src/Worker.scala
@@ -60,15 +60,7 @@ private final class Worker(
     while alive.get() do
       sensor.createConnectionStarted()
       try
-        val res =
-          connection match
-            case Configuration.Connection.NoCredentials(url) =>
-              DriverManager.getConnection(url)
-            case Configuration.Connection.LoginPassword(url, login, password) =>
-              DriverManager.getConnection(url, login, password)
-            case Configuration.Connection.PropertyBased(url, properties) =>
-              DriverManager.getConnection(url, properties)
-          end match
+        val res = Worker.openConnection(connection)
         sensor.createConnectionSuccessful()
         backoffStrategy.reset()
         return res
@@ -145,4 +137,19 @@ private final class Worker(
         false
     end try
   end validate
+end Worker
+
+
+
+private object Worker:
+  /** Opens a new JDBC connection to the database. */
+  def openConnection(connection: Configuration.Connection): JdbcConnection =
+    connection match
+      case Configuration.Connection.NoCredentials(url) =>
+        DriverManager.getConnection(url)
+      case Configuration.Connection.LoginPassword(url, login, password) =>
+        DriverManager.getConnection(url, login, password)
+      case Configuration.Connection.PropertyBased(url, properties) =>
+        DriverManager.getConnection(url, properties)
+    end match
 end Worker

--- a/sql/database/static/src/backoff/Backoff.scala
+++ b/sql/database/static/src/backoff/Backoff.scala
@@ -1,0 +1,32 @@
+package io.github.maxkar
+package sql.database.static.backoff
+
+
+/**
+ * Back-off strategy management. Indicates how to handle timeouts
+ * between (unsuccessfull) operations.
+ *
+ * The `reset` and `handleFailure` methods are invoked from a single
+ * thread only. The `abortSleep` method may be called from multiple
+ * threads and should be safe in regard with all other methods.
+ */
+trait Backoff:
+  /** Resets the back-off interval after a successfull operation. */
+  def reset(): Unit
+
+
+  /**
+   * Handles a failure by awaiting for some backoff-specific time. Consequent
+   * calls to this method may change the timeout being used.
+   */
+  def handleFailure(): Unit
+
+
+  /**
+   * Instructs the back-off to finish any waits/sleeps in progress,
+   * return from the active `handleFailure` methods and never sleep again.
+   * This method is used when a whole subsystem is shutdown and any pending
+   * back-offs should also be terminated.
+   */
+  def shutdown(): Unit
+end Backoff

--- a/sql/database/static/src/backoff/BackoffFactory.scala
+++ b/sql/database/static/src/backoff/BackoffFactory.scala
@@ -1,0 +1,15 @@
+package io.github.maxkar
+package sql.database.static.backoff
+
+
+/**
+ * Factory for back-off strategies. Individual back-off instances
+ * are responsible for managing backoff timeouts for one object only
+ * (connection, thread, etc...). In many cases multiple managed objects
+ * exists and the factory is used to create individual back-off instances
+ * (similar to threadFactory).
+ */
+trait BackoffFactory:
+  /** Creates a new backoff instance. */
+  def newBackoff(): Backoff
+end BackoffFactory

--- a/sql/database/static/src/backoff/SimpleBackoff.scala
+++ b/sql/database/static/src/backoff/SimpleBackoff.scala
@@ -1,0 +1,64 @@
+package io.github.maxkar
+package sql.database.static.backoff
+
+/**
+ * A simple back-off strategy starting with a fixed interval and then
+ * using the provided function to calculate any further backoffs.
+ *
+ * @param initialBackoffMs initial value of the back-off. Used on a first
+ *   attempt to set the back-off.
+ * @param  maxBackoffMs maximal back-off timeout, timeouts after this value
+ *   would be clipped to it.
+ * @param nextTimeout function used to derive next timeout from the current one.
+ */
+final class SimpleBackoff(initialBackoffMs: Int, maxBackoffMs: Int, nextTimeout: Int => Int)
+    extends Backoff:
+
+  /** Current back-off timeout, used on the next operation. */
+  private var currentBackoffMs: Int = initialBackoffMs
+
+  /** Indicates that the backoff was shut down. */
+  private var wasShutDown: Boolean = false
+
+  /** Incapsulated synchronization primitive. */
+  private val lock = new Object()
+
+
+  override def handleFailure(): Unit =
+    lock synchronized {
+      if wasShutDown then
+        return
+      doSleep(currentBackoffMs)
+    }
+    if !wasShutDown && currentBackoffMs < maxBackoffMs then
+      currentBackoffMs = Math.min(nextTimeout(currentBackoffMs), maxBackoffMs)
+  end handleFailure
+
+
+  override def reset(): Unit =
+    currentBackoffMs = initialBackoffMs
+
+
+  override def shutdown(): Unit =
+    lock synchronized {
+      wasShutDown = true
+      lock.notifyAll()
+    }
+
+
+  /** Performs "notifiable" sleep. */
+  private def doSleep(timeout: Int): Unit =
+    var now = System.currentTimeMillis()
+    val deadline = now + timeout
+    /* Handle spurious wakeups. */
+    while now < deadline do
+      lock.wait(deadline - now)
+      /* But not all wakeups are suprious, we may have been notified. */
+      if wasShutDown then
+        return
+      now = System.currentTimeMillis()
+    end while
+  end doSleep
+
+
+end SimpleBackoff

--- a/sql/database/static/src/backoff/SimpleBackoffFactory.scala
+++ b/sql/database/static/src/backoff/SimpleBackoffFactory.scala
@@ -1,0 +1,22 @@
+package io.github.maxkar
+package sql.database.static.backoff
+
+
+/**
+ * Factory for back-offs that could be described using a simple timeout derivation strategy.
+ *
+ * @param initialBackoffMs initial value of the back-off. Used on a first
+ *   attempt to set the back-off.
+ * @param  maxBackoffMs maximal back-off timeout, timeouts after this value
+ *   would be clipped to it.
+ * @param nextTimeout function used to derive next timeout from the current one.
+ */
+final class SimpleBackoffFactory(
+      initialBackoffMs: Int,
+      maxBackoffMs: Int,
+      nextTimeout: Int => Int
+    ) extends BackoffFactory:
+
+  override def newBackoff(): Backoff =
+    return new SimpleBackoff(initialBackoffMs, maxBackoffMs, nextTimeout)
+end SimpleBackoffFactory

--- a/sql/database/static/src/backoff/Strategies.scala
+++ b/sql/database/static/src/backoff/Strategies.scala
@@ -1,0 +1,23 @@
+package io.github.maxkar
+package sql.database.static.backoff
+
+
+/** Some simple back-off strategies. */
+object Strategies:
+  /** Fixed back-off strategy. */
+  def fixed(timeoutMs: Int): BackoffFactory =
+    new SimpleBackoffFactory(timeoutMs, timeoutMs, identity)
+
+
+  /**
+   * Randomized exponential back-off factory. Uses exponent of 2 and
+   * spread factor equal to the "current" timeout. In simple terms,
+   * for the next timeout it generates value between `2*currentTimeout` and
+   * `3*currentTimeout`.
+   *
+   * @param minValueMs minimal timeout value.
+   * @param maxValueMs maximal timeout value.
+   */
+  def randomizedDoubleExponent(minValueMs: Int, maxValueMs: Int): BackoffFactory =
+    new SimpleBackoffFactory(minValueMs, maxValueMs, v => (v << 2) + scala.util.Random.nextInt(v))
+end Strategies

--- a/sql/database/static/test/ServiceSmokeTest.scala
+++ b/sql/database/static/test/ServiceSmokeTest.scala
@@ -46,6 +46,22 @@ final class ServiceSmokeTest extends org.scalatest.funsuite.AnyFunSuite:
   end CountingThreadFactory
 
 
+  test("Attempt to connect to non-existend DB should throw an exception") {
+    val threadFactory = new CountingThreadFactory()
+    val taskQueue = new FifoTaskProvider()
+
+    val config = new Configuration(
+      connection = Configuration.Connection.LoginPassword("jdbc:hsqldb:hsql://localhost:88/thisisnotadb", "SA", ""),
+      poolSize = 2,
+      threadFactory = threadFactory,
+    )
+
+    assertThrows[Throwable] {
+      Service(config, taskQueue, Sensor.noop)
+    }
+  }
+
+
   test("Basic service operations - running queries and stopping the DB") {
     withTempServer { dbUrl =>
       val threadFactory = new CountingThreadFactory()

--- a/sql/database/static/test/ServiceSmokeTest.scala
+++ b/sql/database/static/test/ServiceSmokeTest.scala
@@ -1,0 +1,111 @@
+package io.github.maxkar
+package sql.database.static
+
+import sql.dialect.standard.given
+import sql.dialect.standard.*
+import sql.syntax.given
+import sql.syntax.*
+
+import java.util.concurrent.Semaphore
+
+import scala.language.implicitConversions
+import io.github.maxkar.sql.connection.AutocommitConnection
+
+/**
+ * Very basic smoke test for the connection service.
+ */
+final class ServiceSmokeTest extends org.scalatest.funsuite.AnyFunSuite:
+  /**
+   * An ID of the "next" database to run.
+   * Tests are run in parallel. We can prevent them from doing so. Or we can
+   * just give every test its own DB. We go with the second approach here.
+   */
+  private val dbIndex = new java.util.concurrent.atomic.AtomicInteger()
+
+
+  /** Thread factory that counts threads. */
+  final class CountingThreadFactory extends java.util.concurrent.ThreadFactory:
+    private val threadCounter = new java.util.concurrent.atomic.AtomicInteger()
+
+    /** Returns current number of active threads. */
+    def activeThreadCount: Int = threadCounter.get()
+
+
+    override def newThread(x: Runnable): Thread =
+      val t = new Thread(new Runnable() {
+        override def run(): Unit =
+          threadCounter.incrementAndGet()
+          try
+            x.run()
+          finally
+            threadCounter.decrementAndGet()
+      })
+      t.setDaemon(true)
+      t
+    end newThread
+  end CountingThreadFactory
+
+
+  test("Basic service operations - running queries and stopping the DB") {
+    import org.hsqldb.Server
+
+    val idx = dbIndex.incrementAndGet()
+    val dbPort = idx + 7845
+    val dbName = s"svcdb${idx}"
+    val server = new Server()
+    server.setDatabaseName(0, dbName)
+    server.setDatabasePath(0, s"mem:${dbName}")
+    server.setPort(dbPort)
+    server.start()
+
+    try
+      val threadFactory = new CountingThreadFactory()
+      val taskQueue = new FifoTaskProvider()
+
+      val config = new Configuration(
+        connection = Configuration.Connection.LoginPassword(s"jdbc:hsqldb:hsql://localhost:${dbPort}/${dbName}", "SA", ""),
+        poolSize = 2,
+        threadFactory = threadFactory,
+      )
+
+      val svc = Service(config, taskQueue, Sensor.noop)
+      Thread.sleep(400)
+      assert(2 === threadFactory.activeThreadCount)
+
+      val smp = new Semaphore(0)
+      taskQueue.submit { conn =>
+        val stmt = conn.jdbcConnection.createStatement()
+        try
+          stmt.execute(
+            "CREATE TABLE test(id INTEGER NOT NULL PRIMARY KEY)"
+          )
+        finally
+          stmt.close()
+        smp.release()
+      }
+      smp.acquire()
+
+
+      for i <- 1 to 10 do
+        taskQueue.submit { conn =>
+          given AutocommitConnection = conn
+          sql"""INSERT INTO test(id) VALUES (${i})""".update()
+          smp.release()
+        }
+
+      smp.acquire(10)
+      var cnt = -1
+      taskQueue.submit { conn =>
+        given AutocommitConnection = conn
+        cnt = sql"""SELECT count(*) FROM test""" select one(int)
+        smp.release()
+      }
+      smp.acquire()
+      assert(cnt === 10)
+
+      svc.shutdown()
+      assert(0 === threadFactory.activeThreadCount)
+    finally
+      server.shutdown()
+  }
+end ServiceSmokeTest


### PR DESCRIPTION
Provide a library that implements "threadpool-like" connection management. It opens the connection, monitors and validates it. It also receives the tasks and then execute them on the connection. The library supports configurable back-off strategy, configurable task queue (which may provide internal priorities) and graceful shutdown.